### PR TITLE
MapBox: use token from ENV file

### DIFF
--- a/src/components/map/MapboxTileLayer.tsx
+++ b/src/components/map/MapboxTileLayer.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react';
 import { TileLayer } from 'react-leaflet';
 
 import { MapboxType } from './types';
-import { MAPBOX_API_KEY as accessToken } from 'config';
+import { MAPBOX_TOKEN as accessToken } from 'config';
 
 export const MapboxTileLayer: FC<MapboxType> = ({ tilesetId }) => {
   const baseUrl = 'https://api.mapbox.com/styles/v1/mapbox';

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,5 +1,4 @@
-export const MAPBOX_API_KEY =
-  'pk.eyJ1IjoiYWJvb2QxMDE2IiwiYSI6ImNrOG5mZWwyODB4eXYzbHBoaXoyMzVpMTIifQ.-NSMo7xsq7Rmq0t0JyizGg';
+export const MAPBOX_TOKEN = process.env.REACT_APP_MAPBOX_TOKEN;
 export const CLOUD_HTML_BASE_URL =
   'https://raw.githubusercontent.com/abettermap/c19-self-report-content/master';
 


### PR DESCRIPTION
Make sure your `.env` is up to date if you test locally. But it should work from deploy as well, and if so then you can rotate the MapBox token for you own acct since it's set up w/the group one now.