### PR TITLE
default birth year scroller to 2020 instead of 1899

### DIFF
--- a/src/components/submission/steps/TestingStep.tsx
+++ b/src/components/submission/steps/TestingStep.tsx
@@ -92,7 +92,6 @@ export const TestingStep: FC<TestingStepType> = ({
                 onChange={handleBirthDate}
                 maxDate={new Date()}
                 label="Birth Month/Year"
-                animateYearScrolling
               />
             </MuiPickersUtilsProvider>
             <FormLabel className={classes.formLabel}>


### PR DESCRIPTION
## What changed

* changed default birth year scroller to 2020 instead of 1899

## What to ignore

* n/a

## What to review

* https://pr-15.d3pqoo7mq9yhwf.amplifyapp.com 