### PR TITLE
Remove Cloudwatch section from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,30 +137,6 @@ import { Component1, Component2 } from 'components';
 - [NYT US
   cases](https://www.nytimes.com/interactive/2020/us/coronavirus-us-cases.html)
 
-### Fixes
-
-- [AWS Amplify react-router
-  issue](https://github.com/aws-amplify/amplify-js/issues/2498#issuecomment-455162939)
-- [Use env vars in React
-  app](https://create-react-app.dev/docs/adding-custom-environment-variables/#referencing-environment-variables-in-the-html)
-
-### Handy tools
-
-- [HTML to Markdown converter](https://markdowntohtml.com/) even puts `id` tags
-  in, easy for linking to with `href` later...
-- [Facebook Sharing
-  Debugger](https://developers.facebook.com/tools/debug/?q=https%3A%2F%2Fwww.covidselfreport.org%2F)
-  is suuuuper handy for seeing why share previews aren't working.
-- [Mapshaper](https://mapshaper.org/) for simplifying/optimizing spatial data in
-  a web GUI.
-- [DynamoDB Geo](https://github.com/rh389/dynamodb-geo.js) later if we want to
-  do spatial queries in Dynamo.
-- [HTML Cleaner](https://html-cleaner.com/) works pretty well for converting
-  Gdocs or Word into HTML sans all the cruft. Need to play w/the "Cleaning
-  options" a bit though.
-- [Livestream: Refactoring to
-  react-query](https://www.youtube.com/watch?v=eEKn8UJfYgc)
-
 ## Data notes
 
 ### Dummy data

--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
-# COVID-19 Untested Tracker
+# COVID-19 Self Reporting Tool ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg) ![Dependabot Status](https://img.shields.io/badge/Dependabot-active-brightgreen.svg)
+
+A website to track global self reported cases and predict future outbreaks. See
+our [About page](https://www.covidselfreport.org/about) for more background on
+the project.
 
 ## Contributing
 
 If you are interested in contributing to our project, read our [contributing
-guidelines](https://github.com/Covid-Self-report-Tool/.github/blob/master/CONTRIBUTING.md) first.
+guidelines](https://github.com/Covid-Self-report-Tool/.github/blob/master/CONTRIBUTING.md)
+first.
 
 ## Local setup
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# COVID-19 Self Reporting Tool ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg) ![Dependabot Status](https://img.shields.io/badge/Dependabot-active-brightgreen.svg)
+# COVID-19 Self Reporting Tool [![license](https://img.shields.io/github/license/peaceiris/actions-gh-pages.svg)](LICENSE) [![Dependabot Status](https://img.shields.io/badge/Dependabot-active-brightgreen.svg)](https://dependabot.com)
 
 A website to track global self reported cases and predict future outbreaks. See
 our [About page](https://www.covidselfreport.org/about) for more background on

--- a/README.md
+++ b/README.md
@@ -186,19 +186,6 @@ super-close zooms anyway). If it doesn't affect how the backend schema and POST
 requests are structured, then let's use the untouched value from Google unless
 we need to start nickel-and-diming perf gains.
 
-## AWS CloudWatch queries
-
-### Parsed `INFO` with response code
-
-```
-parse @message '[*]\t*\t*\t* - - [*] "* * *" * * "*" "*" *' as eventType, stampy, someId, ip, someTimezone, requestType, path, protocol, statusCode, bytes, referrer, userAgent, unknown
-| filter eventType = 'INFO'
-| filter requestType = 'POST'
-| filter path = '/self_report'
-| filter statusCode >= 400
-| display eventType, @timestamp, requestType, path, statusCode, ip
-```
-
 ## Admins
 
 - [Gabriel Abud](https://github.com/Buuntu)


### PR DESCRIPTION
Removes AWS stuff from README, not relevant to contributors.

I also think we should maybe remove "Fixes" and "Handy Tools" sections?  While useful to us I don't think outside contributors really care.  Maybe the "mapshaper" link would still be useful to others but not so sure about the rest.