### PR TITLE
fixing handle sign up error

### DIFF
--- a/src/components/signup/SignupForm.tsx
+++ b/src/components/signup/SignupForm.tsx
@@ -77,7 +77,7 @@ export const SignupForm: FC = () => {
   };
 
   const handleSignupError = (code: string, message: string) => {
-    switch (code) {
+    switch (message) {
       case 'auth/email-already-in-use':
         setFormValue('emailError', 'That email is already in use');
         break;


### PR DESCRIPTION
## Issues resolved by this pull request

Sign up error handling did not work correctly. The screen did not display the correct error messages when the email was already registered or the email was invalid. 

## Issue-specific review items
* [x] an already registered email shows the relevant error message.
* [x] an invalid email shows the relevant error message.
